### PR TITLE
Add name mangling for method and type names to fit foreign language naming conventions

### DIFF
--- a/examples/naming-conventions/Cargo.toml
+++ b/examples/naming-conventions/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uniffi-example-naming-conventions"
+edition = "2018"
+version = "0.1.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_naming_conventions"
+
+[dependencies]
+anyhow = "1.0"
+log = "0.4"
+ffi-support = "0.4"
+uniffi = {path = "../../"}
+
+[build-dependencies]
+uniffi = {path = "../../"}

--- a/examples/naming-conventions/README.md
+++ b/examples/naming-conventions/README.md
@@ -1,0 +1,43 @@
+# Example uniffi component: "Naming Conventions"
+
+This is a small example of how to write a Rust component using uniffi and consume it from Kotlin.
+
+It's designed to exercise our support for name mangling into the conventions expected by the source language and coerced in to the conventions for rust.
+
+e.g. 
+
+calling `getValue()` from kotlin, should call a method called `get_value()` in rust.
+
+We have the following:
+
+* [`./src/naming-conventions.idl`](./src/naming-conventions.idl), the component interface definition which defines some
+  some toy objects and methods with names that don't follow naming conventions for one of the python, rust or kotlin. This is processed by functions in
+  [`./build.rs`](./build.rs) to generate Rust scaffolding for the component.
+* [`./src/lib.rs`](./src/lib.rs), the core implementation of the component in Rust. This basically
+  pulls in the generated Rust scaffolding via `include!()` and fills in function implementations.
+* [`./src/main.rs`](./src/main.rs) generates a helper executable that can be used for working with
+  foreign language bindings, while guaranteeing that those bindings use the same version of `uniffi`
+  as the compiled component.
+* A tiny example kotlin script in [`./example.kts`](./example.kts) that imports the component, calls
+  some of its methods and prints the results.
+
+If you want to try it out, you will need:
+
+* The [Kotlin command-line tools](https://kotlinlang.org/docs/tutorials/command-line.html), particularly `kotlinc`.
+* The [Java Native Access](https://github.com/java-native-access/jna#download) JAR downloaded and its path
+  added to your `$CLASSPATH` environment variable.
+
+With that in place, try the following:
+
+* Run `cargo build`. That compiles the component implementation into a native library named `uniffi_geometry`
+  in `./target/debug/`.
+* Run `cargo run -- generate`. That generates component bindings for Kotlin and compiles them into
+  `./target/debug/geometry.jar`.
+* Run `cargo run -- exec example.kts`. That uses the generated bindings to do show rountripping
+  from Kotlin, and prints out the results.
+* Run `cargo run -- exec example.py`. That uses the generated bindings to do show rountripping
+from Python, and prints out the results.
+* Run `cargo. run -- exec` to get a Kotlin shell in which you can import the bindings for yourself
+  and play around with them.
+
+There is a *lot* of build and packaging detail to figure out here, but the basics seem to work OK.

--- a/examples/naming-conventions/build.rs
+++ b/examples/naming-conventions/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_component_scaffolding("./src/naming-conventions.idl").unwrap();
+}

--- a/examples/naming-conventions/example.kts
+++ b/examples/naming-conventions/example.kts
@@ -1,0 +1,6 @@
+import uniffi.naming_conventions.*;
+
+val camelCaseObject = camelCaseMethod(1)
+val snakeCaseObject = snakeCaseMethod(2)
+println("object1 is camelCase: ${camelCaseObject}")
+println("object2 is not snake_case: ${snakeCaseObject}")

--- a/examples/naming-conventions/example.kts
+++ b/examples/naming-conventions/example.kts
@@ -1,6 +1,10 @@
 import uniffi.naming_conventions.*;
 
-val camelCaseObject = camelCaseMethod(1)
-val snakeCaseObject = snakeCaseMethod(2)
+val camelCaseObject = camelCaseMethod(1, Case.CAMEL_CASE)
+val snakeCaseObject = snakeCaseMethod(2, Case.SNAKE_CASE)
+
 println("object1 is camelCase: ${camelCaseObject}")
 println("object2 is not snake_case: ${snakeCaseObject}")
+
+val case = getSnakeCase()
+println("case is SNAKE_CASE?: ${case}")

--- a/examples/naming-conventions/example.py
+++ b/examples/naming-conventions/example.py
@@ -1,6 +1,9 @@
 from naming_conventions import *
 
-camel_case_object = camel_case_method(1)
-snake_case_object = snake_case_method(2)
-print("object1 is not camelCase: {}".format(camel_case_object))
+camel_case_object = camel_case_method(1, Case.SNAKE_CASE)
+snake_case_object = snake_case_method(2, Case.CAMEL_CASE)
+print("object1 is camelCase: {}".format(camel_case_object))
 print("object2 is snake_case: {}".format(snake_case_object))
+
+case = get_camel_case()
+print("case is UPPER_CAMEL_CASE?: {}".format(case))

--- a/examples/naming-conventions/example.py
+++ b/examples/naming-conventions/example.py
@@ -1,0 +1,6 @@
+from naming_conventions import *
+
+camel_case_object = camel_case_method(1)
+snake_case_object = snake_case_method(2)
+print("object1 is not camelCase: {}".format(camel_case_object))
+print("object2 is snake_case: {}".format(snake_case_object))

--- a/examples/naming-conventions/src/lib.rs
+++ b/examples/naming-conventions/src/lib.rs
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[derive(Debug, Clone)]
+struct SnakeCaseObject {
+    id: u32,
+}
+
+#[derive(Debug, Clone)]
+struct CamelCaseObject {
+    id: u32,
+}
+
+fn camel_case_method(id: u32) -> CamelCaseObject {
+    CamelCaseObject { id }
+}
+
+fn snake_case_method(id: u32) -> SnakeCaseObject {
+    SnakeCaseObject { id }
+}
+
+include!(concat!(env!("OUT_DIR"), "/naming-conventions.uniffi.rs"));

--- a/examples/naming-conventions/src/lib.rs
+++ b/examples/naming-conventions/src/lib.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #[derive(Debug, Clone)]
-struct SnakeCaseObject {
+struct snake_case_object {
     id: u32,
 }
 
@@ -12,12 +12,12 @@ struct CamelCaseObject {
     id: u32,
 }
 
-fn camel_case_method(id: u32) -> CamelCaseObject {
+fn camelCaseMethod(id: u32) -> CamelCaseObject {
     CamelCaseObject { id }
 }
 
-fn snake_case_method(id: u32) -> SnakeCaseObject {
-    SnakeCaseObject { id }
+fn snake_case_method(id: u32) -> snake_case_object {
+    snake_case_object { id }
 }
 
 include!(concat!(env!("OUT_DIR"), "/naming-conventions.uniffi.rs"));

--- a/examples/naming-conventions/src/lib.rs
+++ b/examples/naming-conventions/src/lib.rs
@@ -12,12 +12,27 @@ struct CamelCaseObject {
     id: u32,
 }
 
-fn camelCaseMethod(id: u32) -> CamelCaseObject {
+enum Case {
+    snake_case,
+    UpperCamelCase,
+    camelCase,
+    SHOUTY_SNAKE_CASE,
+}
+
+fn camelCaseMethod(id: u32, _from: Case) -> CamelCaseObject {
     CamelCaseObject { id }
 }
 
-fn snake_case_method(id: u32) -> snake_case_object {
+fn snake_case_method(id: u32, _from: Case) -> snake_case_object {
     snake_case_object { id }
+}
+
+fn get_snake_case() -> Case {
+    Case::snake_case
+}
+
+fn getCamelCase() -> Case {
+    Case::UpperCamelCase
 }
 
 include!(concat!(env!("OUT_DIR"), "/naming-conventions.uniffi.rs"));

--- a/examples/naming-conventions/src/main.rs
+++ b/examples/naming-conventions/src/main.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::run_bindgen_for_component("naming_conventions").unwrap();
+}

--- a/examples/naming-conventions/src/naming-conventions.idl
+++ b/examples/naming-conventions/src/naming-conventions.idl
@@ -1,7 +1,16 @@
+enum Case {
+  "snake_case",
+  "UpperCamelCase",
+  "camelCase",
+  "SHOUTY_SNAKE_CASE",
+};
 
 namespace naming_conventions {
-  snake_case_object snake_case_method(u32 id);
-  CamelCaseObject camelCaseMethod(u32 id);
+  snake_case_object snake_case_method(u32 id, Case src);
+  CamelCaseObject camelCaseMethod(u32 id, Case src);
+
+  Case get_snake_case();
+  Case getCamelCase();
 };
 
 dictionary snake_case_object {

--- a/examples/naming-conventions/src/naming-conventions.idl
+++ b/examples/naming-conventions/src/naming-conventions.idl
@@ -1,0 +1,13 @@
+
+namespace naming_conventions {
+  snake_case_object snake_case_method(u32 id);
+  CamelCaseObject camelCaseMethod(u32 id);
+};
+
+dictionary snake_case_object {
+  u32 id;
+};
+
+dictionary CamelCaseObject {
+  u32 id;
+};

--- a/src/bindings/kotlin/gen_kotlin.rs
+++ b/src/bindings/kotlin/gen_kotlin.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use askama::Template;
+use heck::{ CamelCase, MixedCase };
 
 use crate::interface::*;
 
@@ -365,7 +366,7 @@ internal interface _UniFFILib : Library {
     {%- match func.return_type() -%}
     {%- when Some with (return_type) %}
 
-        fun {{ func.name() }}(
+        fun {{ func.name()|fn_name_kt }}(
             {%- for arg in func.arguments() %}
                 {{ arg.name() }}: {{ arg.type_()|decl_kt }}{% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
@@ -380,7 +381,7 @@ internal interface _UniFFILib : Library {
 
     {% when None -%}
 
-        fun {{ func.name() }}(
+        fun {{ func.name()|fn_name_kt }}(
             {%- for arg in func.arguments() %}
                 {{ arg.name() }}: {{ arg.type_()|decl_kt }}{% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
@@ -412,7 +413,7 @@ class {{ obj.name() }}(handle: Long) {
     // XXX TODO: destructors or equivalent.
 
     {%- for meth in obj.methods() %}
-    fun {{ meth.name() }}(
+    fun {{ meth.name()|fn_name_kt }}(
         {% for arg in meth.arguments() %}
         {{ arg.name() }}: {{ arg.type_()|decl_kt }}{% if loop.last %}{% else %}, {% endif %}
         {% endfor %}
@@ -470,6 +471,10 @@ mod filters {
             TypeReference::Object(_) => "Long".to_string(),
             _ => decl_kt(type_)?,
         })
+    }
+
+    pub fn fn_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+        Ok(nm.to_string().to_mixed_case())
     }
 
     pub fn lower_kt(nm: &dyn fmt::Display, type_: &TypeReference) -> Result<String, askama::Error> {

--- a/src/bindings/kotlin/gen_kotlin.rs
+++ b/src/bindings/kotlin/gen_kotlin.rs
@@ -274,23 +274,23 @@ internal interface _UniFFILib : Library {
     {% for func in ci.iter_ffi_function_definitions() -%}
         fun {{ func.name() }}(
         {%- for arg in func.arguments() %}
-            {{ arg.name() }}: {{ arg.type_()|decl_c }}{% if loop.last %}{% else %},{% endif %}
+            {{ arg.name() }}: {{ arg.type_()|type_c }}{% if loop.last %}{% else %},{% endif %}
         {%- endfor %}
         // TODO: When we implement error handling, there will be an out error param here.
-        ): {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|decl_c }}{% when None %}Unit{% endmatch %}
+        ): {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|type_c }}{% when None %}Unit{% endmatch %}
     {% endfor -%}
 }
 
 // Public interface members begin here.
 
 {% for e in ci.iter_enum_definitions() %}
-    enum class {{ e.name()|decl_name_kt }} {
+    enum class {{ e.name()|class_name_kt }} {
         {% for value in e.values() %}
         {{ value }}{% if loop.last %};{% else %},{% endif %}
         {% endfor %}
 
         companion object {
-            internal fun lift(n: Int): {{ e.name()|decl_name_kt }} {
+            internal fun lift(n: Int): {{ e.name()|class_name_kt }} {
                 return when (n) {
                   {% for value in e.values() %}
                   {{ loop.index }} -> {{ value }}
@@ -301,8 +301,8 @@ internal interface _UniFFILib : Library {
                 }
             }
 
-            internal fun liftFrom(buf: ByteBuffer): {{ e.name()|decl_name_kt }} {
-                return {{ e.name()|decl_name_kt }}.lift(Int.liftFrom(buf))
+            internal fun liftFrom(buf: ByteBuffer): {{ e.name()|class_name_kt }} {
+                return {{ e.name()|class_name_kt }}.lift(Int.liftFrom(buf))
             }
         }
 
@@ -321,19 +321,19 @@ internal interface _UniFFILib : Library {
 {%- endfor -%}
 
 {%- for rec in ci.iter_record_definitions() %}
-    data class {{ rec.name()|decl_name_kt }} (
+    data class {{ rec.name()|class_name_kt }} (
       {%- for field in rec.fields() %}
-        val {{ field.name() }}: {{ field.type_()|decl_kt }}{% if loop.last %}{% else %},{% endif %}
+        val {{ field.name() }}: {{ field.type_()|type_kt }}{% if loop.last %}{% else %},{% endif %}
       {%- endfor %}
     ) {
       companion object {
           // XXX TODO: put this in a superclass maybe?
-          internal fun lift(rbuf: RustBuffer.ByValue): {{ rec.name()|decl_name_kt }} {
-              return liftFromRustBuffer(rbuf) { buf -> {{ rec.name()|decl_name_kt }}.liftFrom(buf) }
+          internal fun lift(rbuf: RustBuffer.ByValue): {{ rec.name()|class_name_kt }} {
+              return liftFromRustBuffer(rbuf) { buf -> {{ rec.name()|class_name_kt }}.liftFrom(buf) }
           }
 
-          internal fun liftFrom(buf: ByteBuffer): {{ rec.name()|decl_name_kt }} {
-              return {{ rec.name()|decl_name_kt }}(
+          internal fun liftFrom(buf: ByteBuffer): {{ rec.name()|class_name_kt }} {
+              return {{ rec.name()|class_name_kt }}(
                 {%- for field in rec.fields() %}
                 {{ "buf"|lift_from_kt(field.type_()) }}{% if loop.last %}{% else %},{% endif %}
                 {%- endfor %}
@@ -368,9 +368,9 @@ internal interface _UniFFILib : Library {
 
         fun {{ func.name()|fn_name_kt }}(
             {%- for arg in func.arguments() %}
-                {{ arg.name() }}: {{ arg.type_()|decl_kt }}{% if loop.last %}{% else %},{% endif %}
+                {{ arg.name() }}: {{ arg.type_()|type_kt }}{% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
-        ): {{ return_type|decl_kt }} {
+        ): {{ return_type|type_kt }} {
             val _retval = _UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
                 {%- for arg in func.arguments() %}
                 {{ arg.name()|lower_kt(arg.type_()) }}{% if loop.last %}{% else %},{% endif %}
@@ -383,7 +383,7 @@ internal interface _UniFFILib : Library {
 
         fun {{ func.name()|fn_name_kt }}(
             {%- for arg in func.arguments() %}
-                {{ arg.name() }}: {{ arg.type_()|decl_kt }}{% if loop.last %}{% else %},{% endif %}
+                {{ arg.name() }}: {{ arg.type_()|type_kt }}{% if loop.last %}{% else %},{% endif %}
             {%- endfor %}
         ) {
             UniFFILib.INSTANCE.{{ func.ffi_func().name() }}(
@@ -397,10 +397,10 @@ internal interface _UniFFILib : Library {
 {% endfor %}
 
 {% for obj in ci.iter_object_definitions() %}
-class {{ obj.name()|decl_name_kt }}(handle: Long) {
+class {{ obj.name()|class_name_kt }}(handle: Long) {
     private var handle: AtomicLong = AtomicLong(handle)
     {%- for cons in obj.constructors() %}
-    constructor({% for arg in cons.arguments() %}{{ arg.name() }}: {{ arg.type_()|decl_kt }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}) :
+    constructor({% for arg in cons.arguments() %}{{ arg.name() }}: {{ arg.type_()|type_kt }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}) :
         this(
             _UniFFILib.INSTANCE.{{ cons.ffi_func().name() }}(
                 {%- for arg in cons.arguments() %}
@@ -415,9 +415,9 @@ class {{ obj.name()|decl_name_kt }}(handle: Long) {
     {%- for meth in obj.methods() %}
     fun {{ meth.name()|fn_name_kt }}(
         {% for arg in meth.arguments() %}
-        {{ arg.name() }}: {{ arg.type_()|decl_kt }}{% if loop.last %}{% else %}, {% endif %}
+        {{ arg.name() }}: {{ arg.type_()|type_kt }}{% if loop.last %}{% else %}, {% endif %}
         {% endfor %}
-    ): {% match meth.return_type() %}{% when Some with (type_) %}{{ type_|decl_kt }}{% when None %}Unit{% endmatch %} {
+    ): {% match meth.return_type() %}{% when Some with (type_) %}{{ type_|type_kt }}{% when None %}Unit{% endmatch %} {
         val _retval = _UniFFILib.INSTANCE.{{ meth.ffi_func().name() }}(
             this.handle.get(){% if meth.arguments().len() > 0 %},{% endif %}
             {%- for arg in meth.arguments() %}
@@ -445,7 +445,7 @@ mod filters {
     use super::*;
     use std::fmt;
 
-    pub fn decl_kt(type_: &TypeReference) -> Result<String, askama::Error> {
+    pub fn type_kt(type_: &TypeReference) -> Result<String, askama::Error> {
         Ok(match type_ {
             // These native Kotlin types map nicely to the FFI without conversion.
             TypeReference::U32 => "Int".to_string(),
@@ -455,25 +455,25 @@ mod filters {
             TypeReference::Bytes => "RustBuffer.ByValue".to_string(),
             // These types need conversation, and special handling for lifting/lowering.
             TypeReference::Boolean => "Boolean".to_string(),
-            TypeReference::Enum(name) => decl_name_kt(name)?,
-            TypeReference::Record(name) => decl_name_kt(name)?,
-            TypeReference::Optional(t) => format!("{}?", decl_kt(t)?),
-            _ => panic!("[TODO: decl_kt({:?})]", type_),
+            TypeReference::Enum(name) => class_name_kt(name)?,
+            TypeReference::Record(name) => class_name_kt(name)?,
+            TypeReference::Optional(t) => format!("{}?", type_kt(t)?),
+            _ => panic!("[TODO: type_kt({:?})]", type_),
         })
     }
 
-    pub fn decl_c(type_: &TypeReference) -> Result<String, askama::Error> {
+    pub fn type_c(type_: &TypeReference) -> Result<String, askama::Error> {
         Ok(match type_ {
             TypeReference::Boolean => "Byte".to_string(),
             TypeReference::Enum(_) => "Int".to_string(),
             TypeReference::Record(_) => "RustBuffer.ByValue".to_string(),
             TypeReference::Optional(_) => "RustBuffer.ByValue".to_string(),
             TypeReference::Object(_) => "Long".to_string(),
-            _ => decl_kt(type_)?,
+            _ => type_kt(type_)?,
         })
     }
 
-    pub fn decl_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn class_name_kt(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_camel_case())
     }
 
@@ -534,7 +534,7 @@ mod filters {
                 nm,
                 lift_from_kt(&"buf", t)?
             ),
-            _ => format!("{}.lift({})", decl_kt(type_)?, nm),
+            _ => format!("{}.lift({})", type_kt(type_)?, nm),
         })
     }
 
@@ -549,7 +549,7 @@ mod filters {
                 nm,
                 lift_from_kt(&"buf", t)?
             ),
-            _ => format!("{}.liftFrom({})", decl_kt(type_)?, nm),
+            _ => format!("{}.liftFrom({})", type_kt(type_)?, nm),
         })
     }
 }

--- a/src/bindings/python/gen_python.rs
+++ b/src/bindings/python/gen_python.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use askama::Template;
-use heck::SnakeCase;
+use heck::{ SnakeCase, CamelCase };
 
 use crate::interface::*;
 
@@ -220,7 +220,7 @@ def {{ func.name()|fn_name_py }}({% for arg in func.arguments() %}{{ arg.name() 
 {% endfor %}
 
 {% for obj in ci.iter_object_definitions() %}
-class {{ obj.name() }}(object):
+class {{ obj.name()|decl_name_py }}(object):
     # XXX TODO: support for multiple constructors...
     {%- for cons in obj.constructors() %}
     def __init__(self, {% for arg in cons.arguments() %}{{ arg.name() }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}):
@@ -295,6 +295,10 @@ mod filters {
             TypeReference::Object(_) => "ctypes.c_uint64".to_string(),
             _ => panic!("[TODO: decl_c({:?})", type_),
         })
+    }
+
+    pub fn decl_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+        Ok(nm.to_string().to_camel_case())
     }
 
     pub fn fn_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {

--- a/src/bindings/python/gen_python.rs
+++ b/src/bindings/python/gen_python.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use askama::Template;
-use heck::{ SnakeCase, CamelCase };
+use heck::{ SnakeCase, CamelCase, ShoutySnakeCase };
 
 use crate::interface::*;
 
@@ -160,7 +160,7 @@ _UniFFILib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Som
 {% for e in ci.iter_enum_definitions() %}
 class {{ e.name() }}(enum.Enum):
     {% for value in e.values() -%}
-    {{ value }} = {{ loop.index }}
+    {{ value|enum_name_py }} = {{ loop.index }}
     {% endfor -%}
 {%- endfor -%}
 
@@ -309,6 +309,10 @@ mod filters {
 
     pub fn fn_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_snake_case())
+    }
+
+    pub fn enum_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+        Ok(nm.to_string().to_shouty_snake_case())
     }
 
     pub fn coerce_py(

--- a/src/bindings/python/gen_python.rs
+++ b/src/bindings/python/gen_python.rs
@@ -149,10 +149,10 @@ _UniFFILib = loadIndirect(componentName="{{ ci.namespace() }}")
 {%- for func in ci.iter_ffi_function_definitions() %}
 _UniFFILib.{{ func.name() }}.argtypes = (
     {%- for arg in func.arguments() %}
-    {{ arg.type_()|decl_c }},
+    {{ arg.type_()|type_c }},
     {%- endfor %}
 )
-_UniFFILib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some with (type_) %}{{ type_|decl_c }}{% when None %}None{% endmatch %}
+_UniFFILib.{{ func.name() }}.restype = {% match func.return_type() %}{% when Some with (type_) %}{{ type_|type_c }}{% when None %}None{% endmatch %}
 {%- endfor %}
 
 # Public interface members begin here.
@@ -226,7 +226,7 @@ def {{ func.name()|fn_name_py }}({% for arg in func.arguments() %}{{ arg.name() 
 {% endfor %}
 
 {% for obj in ci.iter_object_definitions() %}
-class {{ obj.name()|decl_name_py }}(object):
+class {{ obj.name()|class_name_py }}(object):
     # XXX TODO: support for multiple constructors...
     {%- for cons in obj.constructors() %}
     def __init__(self, {% for arg in cons.arguments() %}{{ arg.name() }}{% if loop.last %}{% else %}, {% endif %}{% endfor %}):
@@ -287,7 +287,7 @@ mod filters {
     use super::*;
     use std::fmt;
 
-    pub fn decl_c(type_: &TypeReference) -> Result<String, askama::Error> {
+    pub fn type_c(type_: &TypeReference) -> Result<String, askama::Error> {
         Ok(match type_ {
             TypeReference::U32 => "ctypes.c_uint32".to_string(),
             TypeReference::U64 => "ctypes.c_uint64".to_string(),
@@ -299,11 +299,11 @@ mod filters {
             TypeReference::Record(_) => "RustBuffer".to_string(),
             TypeReference::Optional(_) => "RustBuffer".to_string(),
             TypeReference::Object(_) => "ctypes.c_uint64".to_string(),
-            _ => panic!("[TODO: decl_c({:?})", type_),
+            _ => panic!("[TODO: type_c({:?})", type_),
         })
     }
 
-    pub fn decl_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
+    pub fn class_name_py(nm: &dyn fmt::Display) -> Result<String, askama::Error> {
         Ok(nm.to_string().to_camel_case())
     }
 

--- a/src/bindings/python/gen_python.rs
+++ b/src/bindings/python/gen_python.rs
@@ -127,6 +127,12 @@ class RustBufferStream(object):
     def putDouble(self, v):
         self._pack_into(8, ">d", v)
 
+    def getInt(self):
+        return self._unpack_from(4, ">i")
+
+    def putInt(self, v):
+        self._pack_into(8, ">i", v)
+        
 def liftOptional(rbuf, liftFrom):
     return liftFromOptional(RustBufferStream(rbuf), liftFrom)
 
@@ -345,6 +351,7 @@ mod filters {
         type_: &TypeReference,
     ) -> Result<String, askama::Error> {
         Ok(match type_ {
+            TypeReference::U32 => "4".to_string(),
             TypeReference::Double => "8".to_string(),
             TypeReference::Record(type_name) => format!("{}._lowersIntoSize({})", type_name, nm),
             _ => panic!("[TODO: lowers_into_size_py({:?})]", type_),
@@ -357,6 +364,7 @@ mod filters {
     ) -> Result<String, askama::Error> {
         Ok(match type_ {
             TypeReference::Double => format!("{}.putDouble({})", target, nm),
+            TypeReference::U32 => format!("{}.putInt({})", target, nm),
             TypeReference::Record(type_name) => {
                 format!("{}._lowerInto({}, {})", type_name, nm, target)
             }
@@ -387,6 +395,7 @@ mod filters {
         type_: &TypeReference,
     ) -> Result<String, askama::Error> {
         Ok(match type_ {
+            TypeReference::U32 => format!("{}.getInt()", nm),
             TypeReference::Double => format!("{}.getDouble()", nm),
             TypeReference::Record(type_name) => format!("{}._liftFrom({})", type_name, nm),
             _ => panic!("[TODO: lift_from_py({:?})]", type_),


### PR DESCRIPTION
This PR may not be useful, but starts as a way of exploring the codebase. Absenting some issues ;)

* The IDL may specify method names in camel case or snake case.
* The generated kotlin method names are in camel case. 
* The generated python method names are in snake case.
* The rust method names are in snake case.

Is this useful? 

* If the rust devs are delivering generated APIs to App developers, then yes. 
* If the rust devs are delivering handmade wrappers around the generated APIs, then no. 

This should probably be a candidate for project specific/language specific `uniffi` config.