### PR TITLE
Adds String support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   Rust and Foreign Language tests:
     docker:
       - image: rfkelly/uniffi-ci:latest
-    resource_class: small
+    resource_class: medium
     steps:
       - run: cat ~/.profile >> $BASH_ENV
       - checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
   "examples/arithmetic",
   "examples/geometry",
   "examples/sprites",
+  "examples/todolist"
 ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,5 +12,6 @@ Newcomers are recommended to explore them in the following order:
   data.
 * [`./sprites/`](./sprites/) shows how to work with stateful objects that have methods, in classical
   object-oriented style.
+* [`./todolist`](./todolist/) Simple todolist that only adds items and shows the last item, meant to show how interacting with strings works.
 * [`./fxa-client`](./fxa-client/) doesn't work yet, but it contains aspirational example of what the IDL
   might look like for an actual real-world component.

--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "uniffi-example-todolist"
+edition = "2018"
+version = "0.1.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+name = "uniffi_todolist"
+
+[dependencies]
+anyhow = "1.0"
+log = "0.4"
+ffi-support = "0.4"
+lazy_static = "1.4"
+uniffi = {path = "../../uniffi"}
+uniffi_macros = {path = "../../uniffi_macros"}
+
+[build-dependencies]
+uniffi = {path = "../../uniffi"}

--- a/examples/todolist/README.md
+++ b/examples/todolist/README.md
@@ -1,0 +1,38 @@
+# Example uniffi component: "Todolist"
+
+This example is designed to demonstrate a simple interaction using strings.
+
+* [`./src/todolist.idl`](./src/todolist.idl), the component interface definition which defines the main object and its methods. This is processed by functions in [`./build.rs`](./build.rs)
+  to generate Rust scaffolding for the component.
+* [`./src/lib.rs`](./src/lib.rs), the core implementation of the component in Rust. This basically
+  pulls in the generated Rust scaffolding via `include!()` and fills in function implementations.
+* [`./src/main.rs`](./src/main.rs) generates a helper executable that can be used for working with
+  foreign language bindings, while guaranteeing that those bindings use the same version of `uniffi`
+  as the compiled component.
+* Some small test scripts that double as API examples in each target foreign language:
+  * Kotlin [`./tests/bindings/test_todolist.kts`](./tests/bindings/test_todolist.kts)
+  * Swift [`./tests/bindings/test_todolist.swift`](./tests/bindings/test_todolist.swift)
+  * Python [`./tests/bindings/test_todolist.py`](./tests/bindings/test_todolist.py)
+
+If you want to try it out, you will need:
+
+* The [Kotlin command-line tools](https://kotlinlang.org/docs/tutorials/command-line.html), particularly `kotlinc`.
+* The [Java Native Access](https://github.com/java-native-access/jna#download) JAR downloaded and its path
+  added to your `$CLASSPATH` environment variable.
+* Python 3
+* The [Swift command-line tools](https://swift.org/download/), particularly `swift`, `swiftc` and
+  the `Foundation` package.
+
+With that in place, try the following:
+
+* Run `cargo build`. That compiles the component implementation into a native library named `uniffi_todolist`
+  in `../../target/debug/`.
+* Run `cargo run -- generate`. That generates component bindings for each target language:
+    * `../../target/debug/todolist.kt` for Kotlin
+    * `../../target/debug/todolist.swift` for Swift
+    * `../../target/debug/todolist.py` for Python
+* Run `cargo test`. This exercises the foreign language bindings via the scripts in `./tests/bindings/`.
+* Run `cargo run -- exec tests/bindings/test_todolist.kts`. This will directly execute the Kotlin
+  test script. Try the same for the other languages.
+* Run `cargo. run -- exec -l python` to get a Python shell in which you can import the generated
+  module for yourself and play around with it. Try `import todolist` and go from there!

--- a/examples/todolist/build.rs
+++ b/examples/todolist/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_component_scaffolding("./src/todolist.idl").unwrap();
+}

--- a/examples/todolist/src/lib.rs
+++ b/examples/todolist/src/lib.rs
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[derive(Debug, Clone)]
+struct TodoEntry {
+    text: String,
+}
+
+// I am a simple Todolist
+#[derive(Debug, Clone)]
+struct TodoList {
+    items: Vec<String>,
+}
+
+impl TodoList {
+    fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    fn add_item<S: Into<String>>(&mut self, item: S) {
+        self.items.push(item.into())
+    }
+
+    fn get_last(&self) -> String {
+        self.items.last().cloned().unwrap()
+    }
+
+    fn add_entry(&mut self, entry: TodoEntry) {
+        self.items.push(entry.text)
+    }
+
+    fn get_last_entry(&self) -> TodoEntry {
+        TodoEntry {
+            text: self.items.last().cloned().unwrap(),
+        }
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/todolist.uniffi.rs"));

--- a/examples/todolist/src/main.rs
+++ b/examples/todolist/src/main.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::run_bindgen_for_component("todolist").unwrap();
+}

--- a/examples/todolist/src/todolist.idl
+++ b/examples/todolist/src/todolist.idl
@@ -1,0 +1,14 @@
+namespace todolist {
+};
+
+dictionary TodoEntry {
+    string text;
+};
+
+interface TodoList {
+    constructor();
+    void add_item(string todo);
+    void add_entry(TodoEntry entry);
+    TodoEntry get_last_entry();
+    string get_last();
+};

--- a/examples/todolist/tests/bindings/test_todolist.kts
+++ b/examples/todolist/tests/bindings/test_todolist.kts
@@ -1,0 +1,23 @@
+import uniffi.todolist.*
+
+val todo = TodoList()
+todo.addItem("Write strings support")
+
+assert(todo.getLast() == "Write strings support")
+
+todo.addItem("Write tests for strings support")
+
+assert(todo.getLast() == "Write tests for strings support")
+
+val entry = TodoEntry("Write bindings for strings as record members")
+
+todo.addEntry(entry)
+assert(todo.getLast() == "Write bindings for strings as record members")
+assert(todo.getLastEntry().text == "Write bindings for strings as record members")
+
+todo.addItem("Test Ünicode hàndling without an entry can't believe I didn't test this at first 🤣")
+assert(todo.getLast() == "Test Ünicode hàndling without an entry can't believe I didn't test this at first 🤣")
+
+val entry2 = TodoEntry("Test Ünicode hàndling in an entry can't believe I didn't test this at first 🤣")
+todo.addEntry(entry2)
+assert(todo.getLastEntry().text == "Test Ünicode hàndling in an entry can't believe I didn't test this at first 🤣")

--- a/examples/todolist/tests/bindings/test_todolist.py
+++ b/examples/todolist/tests/bindings/test_todolist.py
@@ -1,0 +1,25 @@
+from todolist import *
+
+todo = TodoList()
+
+entry = TodoEntry("Write bindings for strings in records")
+
+todo.add_item("Write python bindings")
+
+assert(todo.get_last() == "Write python bindings")
+
+todo.add_item("Write tests for bindings")
+
+assert(todo.get_last() == "Write tests for bindings")
+
+todo.add_entry(entry)
+
+assert(todo.get_last() == "Write bindings for strings in records")
+assert(todo.get_last_entry().text == "Write bindings for strings in records")
+
+todo.add_item("Test Ünicode hàndling without an entry can't believe I didn't test this at first 🤣")
+assert(todo.get_last() == "Test Ünicode hàndling without an entry can't believe I didn't test this at first 🤣")
+
+entry2 = TodoEntry("Test Ünicode hàndling in an entry can't believe I didn't test this at first 🤣")
+todo.add_entry(entry2)
+assert(todo.get_last_entry().text == "Test Ünicode hàndling in an entry can't believe I didn't test this at first 🤣")

--- a/examples/todolist/tests/bindings/test_todolist.swift
+++ b/examples/todolist/tests/bindings/test_todolist.swift
@@ -1,0 +1,20 @@
+import todolist
+
+
+let todo = TodoList()
+todo.add_item(todo: "Write swift bindings")
+assert( todo.get_last() == "Write swift bindings")
+
+todo.add_item(todo: "Write tests for bindings")
+assert(todo.get_last() == "Write tests for bindings")
+
+let entry = TodoEntry(text: "Write bindings for strings as record members")
+todo.add_entry(entry: entry)
+assert(todo.get_last() == "Write bindings for strings as record members")
+
+todo.add_item(todo: "Test Ünicode hàndling without an entry can't believe I didn't test this at first 🤣")
+assert(todo.get_last() == "Test Ünicode hàndling without an entry can't believe I didn't test this at first 🤣")
+
+let entry2 = TodoEntry(text: "Test Ünicode hàndling in an entry can't believe I didn't test this at first 🤣")
+todo.add_entry(entry: entry2)
+assert(todo.get_last_entry() == entry2)

--- a/examples/todolist/tests/test_generated_bindings.rs
+++ b/examples/todolist/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+uniffi_macros::build_foreign_language_testcases!(
+    "tests/bindings/test_todolist.kts",
+    "tests/bindings/test_todolist.swift",
+    "tests/bindings/test_todolist.py"
+);

--- a/uniffi/src/bindings/kotlin/gen_kotlin.rs
+++ b/uniffi/src/bindings/kotlin/gen_kotlin.rs
@@ -47,8 +47,9 @@ mod filters {
             TypeReference::Float => "Float".to_string(),
             TypeReference::Double => "Double".to_string(),
             TypeReference::Bytes => "RustBuffer.ByValue".to_string(),
-            // These types need conversation, and special handling for lifting/lowering.
+            // These types need conversion, and special handling for lifting/lowering.
             TypeReference::Boolean => "Boolean".to_string(),
+            TypeReference::String => "String".to_string(),
             TypeReference::Enum(name) => class_name_kt(name)?,
             TypeReference::Record(name) => class_name_kt(name)?,
             TypeReference::Optional(t) => format!("{}?", type_kt(t)?),
@@ -63,6 +64,24 @@ mod filters {
             TypeReference::Record(_) => "RustBuffer.ByValue".to_string(),
             TypeReference::Optional(_) => "RustBuffer.ByValue".to_string(),
             TypeReference::Object(_) => "Long".to_string(),
+            TypeReference::String => "String".to_string(),
+            // We use a Pointer here specifically for the `free` function
+            // In a perfect world we wouldn't need an extra variant
+            // but our Rust bindings require `Pointer` for the free function
+            // and `String` for other string-accepting functions.
+            TypeReference::RawStringPointer => "Pointer".to_string(),
+            _ => type_kt(type_)?,
+        })
+    }
+
+    pub fn ret_type_c(type_: &TypeReference) -> Result<String, askama::Error> {
+        Ok(match type_ {
+            TypeReference::Boolean => "Byte".to_string(),
+            TypeReference::Enum(_) => "Int".to_string(),
+            TypeReference::Record(_) => "RustBuffer.ByValue".to_string(),
+            TypeReference::Optional(_) => "RustBuffer.ByValue".to_string(),
+            TypeReference::Object(_) => "Long".to_string(),
+            TypeReference::String => "Pointer".to_string(),
             _ => type_kt(type_)?,
         })
     }

--- a/uniffi/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
+++ b/uniffi/src/bindings/kotlin/templates/NamespaceLibraryTemplate.kt
@@ -25,6 +25,6 @@ internal interface _UniFFILib : Library {
             {{ arg.name() }}: {{ arg.type_()|type_c }}{% if loop.last %}{% else %},{% endif %}
         {%- endfor %}
         // TODO: When we implement error handling, there will be an out error param here.
-        ): {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|type_c }}{% when None %}Unit{% endmatch %}
+        ): {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|ret_type_c }}{% when None %}Unit{% endmatch %}
     {% endfor -%}
 }

--- a/uniffi/src/bindings/kotlin/templates/RustBufferHelpers.kt
+++ b/uniffi/src/bindings/kotlin/templates/RustBufferHelpers.kt
@@ -141,6 +141,37 @@ fun Double.lowerInto(buf: ByteBuffer) {
     buf.putDouble(this)
 }
 
+fun String.lower(): String {
+    return this
+}
+
+fun String.lowerInto(buf: ByteBuffer) {
+    val byteArr = this.toByteArray()
+    buf.putInt(byteArr.size)
+    buf.put(byteArr)
+}
+
+fun String.Companion.liftFrom(buf: ByteBuffer): String {
+    val len = Int.liftFrom(buf)
+    val byteArr = ByteArray(len)
+    buf.get(byteArr)
+    return byteArr.toString(Charsets.UTF_8)
+}
+
+fun String.lowersIntoSize(): Int {
+    return this.toByteArray().size + 4
+}
+
+fun String.Companion.lift(ptr: Pointer): String {
+    try {
+        return ptr.getString(0, "utf8")
+    } finally {
+        _UniFFILib.INSTANCE.{{ ci.ffi_string_free().name() }}(ptr)
+    }
+}
+
+
+
 fun<T> lowerOptional(v: T?, lowersIntoSize: (T) -> Int, lowerInto: (T, ByteBuffer) -> Unit): RustBuffer.ByValue {
     return lowerIntoRustBuffer(v, { v -> lowersIntoSizeOptional(v, lowersIntoSize) }, { v, buf -> lowerIntoOptional(v, buf, lowerInto) })
 }

--- a/uniffi/src/bindings/python/gen_python.rs
+++ b/uniffi/src/bindings/python/gen_python.rs
@@ -46,6 +46,13 @@ mod filters {
             TypeReference::Float => "ctypes.c_float".to_string(),
             TypeReference::Double => "ctypes.c_double".to_string(),
             TypeReference::Boolean => "ctypes.c_byte".to_string(),
+            // We use a c_void_p instead of a c_char_p since python seems to
+            // create it's own string if we use c_char_p, and that prevents us
+            // from freeing. I could be wrong, but that's what I got from this:
+            // https://stackoverflow.com/questions/13445568/python-ctypes-how-to-free-memory-getting-invalid-pointer-error
+            TypeReference::String | TypeReference::RawStringPointer => {
+                "ctypes.c_void_p".to_string()
+            }
             TypeReference::Bytes => "RustBuffer".to_string(),
             TypeReference::Enum(_) => "ctypes.c_uint32".to_string(),
             TypeReference::Record(_) => "RustBuffer".to_string(),
@@ -76,6 +83,8 @@ mod filters {
             | TypeReference::U64
             | TypeReference::Float
             | TypeReference::Double
+            | TypeReference::String
+            | TypeReference::RawStringPointer
             | TypeReference::Boolean => format!("{} = {}", nm, nm),
             TypeReference::Enum(type_name) => format!("{} = {}({})", nm, type_name, nm),
             TypeReference::Record(type_name) => format!("{} = {}._coerce({})", nm, type_name, nm),
@@ -92,6 +101,7 @@ mod filters {
             | TypeReference::Double
             | TypeReference::Boolean => nm.to_string(),
             TypeReference::Enum(_) => format!("{}.value", nm),
+            TypeReference::String => format!("{}.encode('utf-8')", nm),
             TypeReference::Record(type_name) => format!("{}._lower({})", type_name, nm),
             TypeReference::Optional(_type) => format!(
                 "lowerOptional({}, lambda buf, v: {})",
@@ -109,6 +119,7 @@ mod filters {
         Ok(match type_ {
             TypeReference::U32 => "4".to_string(),
             TypeReference::Double => "8".to_string(),
+            TypeReference::String => format!("4 + len({}.encode('utf-8'))", nm),
             TypeReference::Record(type_name) => format!("{}._lowersIntoSize({})", type_name, nm),
             _ => panic!("[TODO: lowers_into_size_py({:?})]", type_),
         })
@@ -121,6 +132,7 @@ mod filters {
         Ok(match type_ {
             TypeReference::Double => format!("{}.putDouble({})", target, nm),
             TypeReference::U32 => format!("{}.putInt({})", target, nm),
+            TypeReference::String => format!("{}.putString({})", target, nm),
             TypeReference::Record(type_name) => {
                 format!("{}._lowerInto({}, {})", type_name, nm, target)
             }
@@ -136,6 +148,7 @@ mod filters {
             | TypeReference::Double
             | TypeReference::Boolean => format!("{}", nm),
             TypeReference::Enum(type_name) => format!("{}({})", type_name, nm),
+            TypeReference::String => format!("liftString({})", nm),
             TypeReference::Record(type_name) => format!("{}._lift({})", type_name, nm),
             TypeReference::Optional(type_) => format!(
                 "liftOptional({}, lambda buf: {})",
@@ -154,6 +167,7 @@ mod filters {
             TypeReference::U32 => format!("{}.getInt()", nm),
             TypeReference::Double => format!("{}.getDouble()", nm),
             TypeReference::Record(type_name) => format!("{}._liftFrom({})", type_name, nm),
+            TypeReference::String => format!("{}.getString()", nm),
             _ => panic!("[TODO: lift_from_py({:?})]", type_),
         })
     }

--- a/uniffi/src/bindings/python/templates/RustBufferHelper.py
+++ b/uniffi/src/bindings/python/templates/RustBufferHelper.py
@@ -44,7 +44,16 @@ class RustBufferStream(object):
         return self._unpack_from(4, ">i")
 
     def putInt(self, v):
-        self._pack_into(8, ">i", v)
+        self._pack_into(4, ">i", v)
+
+    def getString(self):
+        numBytes = self.getInt()
+        return self._unpack_from(numBytes, ">{}s".format(numBytes)).decode('utf-8')
+    def putString(self, v):
+        valueBytes = v.encode('utf-8')
+        numBytes = len(valueBytes)
+        self.putInt(numBytes)
+        self._pack_into(numBytes, ">{}s".format(numBytes), valueBytes)
         
 def liftOptional(rbuf, liftFrom):
     return liftFromOptional(RustBufferStream(rbuf), liftFrom)
@@ -53,3 +62,9 @@ def liftFromOptional(buf, liftFrom):
     if buf.getByte() == b"\x00":
         return None
     return liftFrom(buf)
+
+def liftString(cPtr):
+    try:
+        return ctypes.cast(cPtr, ctypes.c_char_p).value.decode('utf-8')
+    finally:
+        _UniFFILib.{{ ci.ffi_string_free().name() }}(cPtr)

--- a/uniffi/src/bindings/swift/gen_swift.rs
+++ b/uniffi/src/bindings/swift/gen_swift.rs
@@ -84,6 +84,31 @@ mod filters {
             TypeReference::Float => "float".into(),
             TypeReference::Double => "double".into(),
             TypeReference::Bytes => "RustBuffer".into(),
+            TypeReference::String | TypeReference::RawStringPointer => {
+                "char const *_Nonnull".into()
+            }
+            // Our FFI lowers Booleans into bytes, to work around JNA bugs.
+            // We'll lift these up into Booleans on the Swift side.
+            TypeReference::Boolean => "uint8_t".into(),
+            // These types need conversion, and special handling for lifting/lowering.
+            TypeReference::Enum(_) => "uint32_t".into(),
+            TypeReference::Record(_) => "RustBuffer".into(),
+            TypeReference::Optional(_) => "RustBuffer".into(),
+            TypeReference::Object(_) => "uint64_t".into(),
+            _ => panic!("[TODO: decl_c({:?})", type_),
+        })
+    }
+
+    /// Declares a C type in the bridging header.
+    pub fn ret_c(type_: &TypeReference) -> Result<String, askama::Error> {
+        Ok(match type_ {
+            // These native types map nicely to the FFI without conversion.
+            TypeReference::U32 => "uint32_t".into(),
+            TypeReference::U64 => "uint64_t".into(),
+            TypeReference::Float => "float".into(),
+            TypeReference::Double => "double".into(),
+            TypeReference::Bytes => "RustBuffer".into(),
+            TypeReference::String => "char *_Nonnull".into(),
             // Our FFI lowers Booleans into bytes, to work around JNA bugs.
             // We'll lift these up into Booleans on the Swift side.
             TypeReference::Boolean => "uint8_t".into(),
@@ -103,6 +128,7 @@ mod filters {
             TypeReference::U64 => "UInt64".into(),
             TypeReference::Float => "Float".into(),
             TypeReference::Double => "Double".into(),
+            TypeReference::String => "String".into(),
             // TypeReference::Bytes => "Data".into(),
             TypeReference::Boolean => "Bool".into(),
             TypeReference::Enum(name) => name.into(),

--- a/uniffi/src/bindings/swift/templates/Template-Bridging-Header.h
+++ b/uniffi/src/bindings/swift/templates/Template-Bridging-Header.h
@@ -12,7 +12,7 @@ typedef struct RustBuffer {
 } RustBuffer;
 
 {% for func in ci.iter_ffi_function_definitions() -%}
-    {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|decl_c }}{% when None %}void{% endmatch %} {{ func.name() }}(
+    {%- match func.return_type() -%}{%- when Some with (type_) %}{{ type_|ret_c }}{% when None %}void{% endmatch %} {{ func.name() }}(
       {%- for arg in func.arguments() %}
       {{ arg.type_()|decl_c }} {{ arg.name() }}{% if loop.last %}{% else %},{% endif %}
       {%- endfor %}

--- a/uniffi/src/interface/mod.rs
+++ b/uniffi/src/interface/mod.rs
@@ -162,6 +162,19 @@ impl<'ci> ComponentInterface {
         }
     }
 
+    pub fn ffi_string_free(&self) -> FFIFunction {
+        FFIFunction {
+            name: format!("{}_string_free", self.namespace()),
+            arguments: vec![Argument {
+                name: "str".to_string(),
+                type_: TypeReference::RawStringPointer,
+                optional: false,
+                default: None,
+            }],
+            return_type: None,
+        }
+    }
+
     pub fn iter_ffi_function_definitions(&self) -> Vec<FFIFunction> {
         self.objects
             .iter()
@@ -174,9 +187,13 @@ impl<'ci> ComponentInterface {
             .flatten()
             .chain(self.functions.iter().map(|f| f.ffi_func.clone()))
             .chain(
-                vec![self.ffi_bytebuffer_alloc(), self.ffi_bytebuffer_free()]
-                    .iter()
-                    .cloned(),
+                vec![
+                    self.ffi_bytebuffer_alloc(),
+                    self.ffi_bytebuffer_free(),
+                    self.ffi_string_free(),
+                ]
+                .iter()
+                .cloned(),
             )
             .collect()
     }

--- a/uniffi/src/interface/types.rs
+++ b/uniffi/src/interface/types.rs
@@ -31,6 +31,12 @@ pub enum TypeReference {
     Float,
     Double,
     String,
+    // I don't like this too much since it's not a part of the IDL, and hopefully I can get rid of it
+    // But keeping it for the draft until I have a better idea
+    // on how to model the freeing. Normal Kotlin functions that take
+    // strings take a "String" across the ffi, but the "free" function
+    // takes a "Pointer".
+    RawStringPointer,
     Bytes,
     Object(String),
     Record(String),

--- a/uniffi/src/scaffolding.rs
+++ b/uniffi/src/scaffolding.rs
@@ -40,9 +40,38 @@ mod filters {
         })
     }
 
+    pub fn ret_type_rs(type_: &TypeReference) -> Result<String, askama::Error> {
+        Ok(match type_ {
+            // These can be passed directly over the FFI without conversion.
+            TypeReference::U32 => "u32".to_string(),
+            TypeReference::U64 => "u64".to_string(),
+            TypeReference::Float => "f32".to_string(),
+            TypeReference::Double => "f64".to_string(),
+            TypeReference::Boolean => "u8".to_string(),
+            // These types need conversion, and will require special handling below
+            // when lifting/lowering.
+            TypeReference::String => "String".to_string(),
+            TypeReference::Enum(name) => name.clone(),
+            TypeReference::Record(name) => name.clone(),
+            TypeReference::Optional(t) => format!("Option<{}>", type_rs(t)?),
+            _ => panic!("[TODO: type_rs({:?})]", type_),
+        })
+    }
+
     pub fn type_c(type_: &TypeReference) -> Result<String, askama::Error> {
         Ok(match type_ {
             TypeReference::String => "ffi_support::FfiStr<'_>".to_string(),
+            TypeReference::Enum(_) => "u32".to_string(),
+            TypeReference::Record(_) => "ffi_support::ByteBuffer".to_string(),
+            TypeReference::Optional(_) => "ffi_support::ByteBuffer".to_string(),
+            TypeReference::Object(_) => "u64".to_string(),
+            _ => type_rs(type_)?,
+        })
+    }
+
+    pub fn ret_type_c(type_: &TypeReference) -> Result<String, askama::Error> {
+        Ok(match type_ {
+            TypeReference::String => "*mut std::os::raw::c_char".to_string(),
             TypeReference::Enum(_) => "u32".to_string(),
             TypeReference::Record(_) => "ffi_support::ByteBuffer".to_string(),
             TypeReference::Optional(_) => "ffi_support::ByteBuffer".to_string(),
@@ -56,7 +85,7 @@ mod filters {
         // implementations of the functions that we're wrapping (and also to type-check our generated code).
         Ok(format!(
             "<{} as uniffi::support::ViaFfi>::into_ffi_value({})",
-            type_rs(type_)?,
+            ret_type_rs(type_)?,
             nm
         ))
     }

--- a/uniffi/src/templates/ObjectTemplate.rs
+++ b/uniffi/src/templates/ObjectTemplate.rs
@@ -45,7 +45,7 @@ lazy_static::lazy_static! {
         {%- for arg in meth.ffi_func().arguments() %}
         {{ arg.name() }}: {{ arg.type_()|type_c }},
         {%- endfor %}
-    ) -> {% match meth.ffi_func().return_type() %}{% when Some with (return_type) %}{{ return_type|type_c }}{% else %}(){% endmatch %} {
+    ) -> {% match meth.ffi_func().return_type() %}{% when Some with (return_type) %}{{ return_type|ret_type_c }}{% else %}(){% endmatch %} {
         log::debug!("{{ meth.ffi_func().name() }}");
         let mut err: ffi_support::ExternError = Default::default(); // XXX TODO: error handling!
         // If the method does not have the same signature as declared in the IDL, then

--- a/uniffi/src/templates/RecordTemplate.rs
+++ b/uniffi/src/templates/RecordTemplate.rs
@@ -18,7 +18,7 @@ impl uniffi::support::Liftable for {{ rec.name() }} {
     fn try_lift_from<B: uniffi::support::Buf>(buf: &mut B) -> anyhow::Result<Self> {
       Ok(Self {
         {%- for field in rec.fields() %}
-            {{ field.name() }}: <{{ field.type_()|type_rs }} as uniffi::support::Liftable>::try_lift_from(buf)?,
+            {{ field.name() }}: <{{ field.type_()|ret_type_rs }} as uniffi::support::Liftable>::try_lift_from(buf)?,
         {%- endfor %}
       })
     }

--- a/uniffi/src/templates/TopLevelFunctionTemplate.rs
+++ b/uniffi/src/templates/TopLevelFunctionTemplate.rs
@@ -9,7 +9,7 @@ pub extern "C" fn {{ func.ffi_func().name() }}(
     {%- for arg in func.ffi_func().arguments() %}
     {{ arg.name() }}: {{ arg.type_()|type_c }},
     {%- endfor %}
-) -> {% match func.ffi_func().return_type() %}{% when Some with (return_type) %}{{ return_type|type_c }}{% else %}(){% endmatch %} {
+) -> {% match func.ffi_func().return_type() %}{% when Some with (return_type) %}{{ return_type|ret_type_c }}{% else %}(){% endmatch %} {
     log::debug!("{{ func.ffi_func().name() }}");
     // If the provided function does not match the signature specified in the IDL
     // then this attempt to cal it will not compile, and will give guideance as to why.

--- a/uniffi/src/templates/scaffolding_template.rs
+++ b/uniffi/src/templates/scaffolding_template.rs
@@ -3,6 +3,10 @@
 
 {% include "RustBuffer.rs" %}
 
+// We add support for freeing strings, some crates won't need this, but it seems safe
+// enough to include anyways since strings are such a common use case.
+ffi_support::define_string_destructor!({{ ci.ffi_string_free().name() }});
+
 // For each enum declared in the IDL, we assume the caller as provided a corresponding
 // rust `enum`. We provide the traits for sending it across the FFI, which will fail to
 // compile if the provided struct has a different shape to the one declared in the IDL.


### PR DESCRIPTION
fixes #3 

Continuation from #22. It got closed since the base branch was deleted, and I couldn't figure out how to re-open it and rebase the PR sooooo here we are.

Anyways, here's the bit of text from that PR: 


- Since we have an asymmetry between arguments and return values, there is some duplication with the `type_c` values
- ~~Another weird side effect of the asymmetry is two `impl`s for ViaFFi, one for the lifting from `FfiStr` to `&str`, and a second for the lowering from `String` to `* mut c_char` there is probably a better way of doing this, but I'm blanking out 😞~~ **Will open an issue to split the `ViaFffi` Trait, I think that will be an awesome first issue for someone else! (I can also do it if it's urgent) Here it is: #26 ** 
- ~~Freeing is **not** implemented yet, I imagine we'd be generating a `free_string` type of api that the bindings can use similar to what is done over at a-s~~ ✅ 
- I am not too familiar with Kotlin/Swift/Python so there is a non-zero chance that I missed something while doing those bindings 😅 
- ~~Haven't thought too much about the `strings as record members` part of #3 so going to test that~~ ✅ 

TODOs before this is ready:
- [x] Implement (or figure out) freeing
- [x] Add tests for strings as record members (I'll add a `TodoEntry` to the todolist example)
- [x] Minimize duplication
- [x] Make the PR target the main branch rather than the test-harness branch

Since all the ticks are there, I think it's ready for review 😄 


